### PR TITLE
Bugfix: Pick up two boxes

### DIFF
--- a/Assets/_Scripts/Game/PlayerController.cs
+++ b/Assets/_Scripts/Game/PlayerController.cs
@@ -224,6 +224,12 @@ public class PlayerController : MonoBehaviour, ITimeTracker
                         }
                     }
                 }
+
+                // break the loop if we found an object bc we can only pick up one object
+                if (isFound)
+                {
+                    break;
+                }
             }
 			
 			// this is when he grabs a object and it shows up in the screen 


### PR DESCRIPTION
Simple fix to prevent player from "picking up" two boxes and one never returning. Just breaking the loop if an object is turned into an item.