### PR TITLE
Getting Player position from snapshot so it isn't the zero vector whe…

### DIFF
--- a/Assets/_Scripts/CameraTracker.cs
+++ b/Assets/_Scripts/CameraTracker.cs
@@ -37,12 +37,12 @@ public class CameraTracker : MonoBehaviour
     {
         if (gameController.TimeStep > 0)
         {
+            Vector2 playerPos = gameController.GetSnapshotValue<Vector2>(gameController.player, gameController.TimeStep,
+                gameController.player.Position.CurrentName);
             //Follow the player's position
             this.transform.position = new Vector3(
-                Mathf.Clamp(gameController.player.transform.position.x, relativeMin.x + startPos.x,
-                    relativeMax.x + startPos.x),
-                Mathf.Clamp(gameController.player.transform.position.y, relativeMin.y + startPos.y,
-                    relativeMax.y + startPos.y),
+                Mathf.Clamp(playerPos.x, relativeMin.x + startPos.x, relativeMax.x + startPos.x),
+                Mathf.Clamp(playerPos.y, relativeMin.y + startPos.y, relativeMax.y + startPos.y),
                 -10);
         }
     }

--- a/Assets/_Scripts/Game/GameController.cs
+++ b/Assets/_Scripts/Game/GameController.cs
@@ -646,7 +646,7 @@ public class GameController : MonoBehaviour
         }
     }
 
-    private T GetSnapshotValue<T>(ITimeTracker timeTracker, int timeStep, string parameter, T defaultValue = default)
+    public T GetSnapshotValue<T>(ITimeTracker timeTracker, int timeStep, string parameter, T defaultValue = default)
     {
         if (SnapshotHistoryById.TryGetValue(timeTracker.ID, out var history))
         {


### PR DESCRIPTION
The camera tracker was using the player gameobject's transform for position, but that is the zero vector when the player is hidden during rewind animation. So using the game snapshot to get the vector instead.