### PR TITLE
Bug fixes

### DIFF
--- a/Assets/_Scripts/Game/ExplodeBox.cs
+++ b/Assets/_Scripts/Game/ExplodeBox.cs
@@ -10,8 +10,6 @@ public class ExplodeBox : BasicTimeTracker
 	public List<ActivatableBehaviour> requiredActivatables = new List<ActivatableBehaviour>();
 	[SerializeField] float distance = 3;
 
-	private int explosionID = -1;
-	
 	public override void Init(GameController gameController, int id)
 	{
 		base.Init(gameController, id);
@@ -52,13 +50,12 @@ public class ExplodeBox : BasicTimeTracker
 		requiredActivatables.Clear();
 		requiredActivatableIDs.Clear();
 		prevActivatableString = null;
-		explosionID = -1;
 	}
 
 	public override void GameUpdate()
     {
 	    // if we are activated AND we haven't already created an explosion object
-        if (AllActivated() && explosionID == -1)
+        if (AllActivated())
         {
 	        bool isInPlayerInv = false;
 	        Vector2 loc = transform.position;
@@ -113,8 +110,7 @@ public class ExplodeBox : BasicTimeTracker
 				}
 			}
 			
-			Explosion explosion = gameController.CreateExplosion(loc, distance); // tell the game controller to create an explosion
-			explosionID = explosion.ID;
+			gameController.CreateExplosion(loc, distance); // tell the game controller to create an explosion
 			
 			FlagDestroy = true; // mark object for destruction in time
         }
@@ -165,20 +161,17 @@ public class ExplodeBox : BasicTimeTracker
 	    base.SaveSnapshot(snapshotDictionary, force);
 	    
 	    snapshotDictionary.Set(nameof(requiredActivatableIDs), string.Join(",", requiredActivatableIDs), force:force);
-	    snapshotDictionary.Set(nameof(explosionID), explosionID, force);
     }
 
     public override void LoadSnapshot(TimeDict.TimeSlice snapshotDictionary)
     {
 	    base.LoadSnapshot(snapshotDictionary);
 		LoadActivatables(snapshotDictionary);
-		explosionID = snapshotDictionary.Get<int>(nameof(explosionID));
     }
     public override void ForceLoadSnapshot(TimeDict.TimeSlice snapshotDictionary)
     {
 	    base.ForceLoadSnapshot(snapshotDictionary);
 	    LoadActivatables(snapshotDictionary);
-	    explosionID = snapshotDictionary.Get<int>(nameof(explosionID));
     }
     
 #if UNITY_EDITOR

--- a/Assets/_Scripts/Game/Explosion.cs
+++ b/Assets/_Scripts/Game/Explosion.cs
@@ -77,7 +77,11 @@ public class Explosion : BasicTimeTracker
 		// if the game is past or at the frame we disappear, destroy us 
 		if (gameController.TimeStep >= destroyStep)
 		{
+			// HACK: remove this object from the history
+			gameController.SetSnapshotValue(this, 0, GameController.FLAG_DESTROY, true, true, true);
+			
 			FlagDestroy = true;
+			gameController.SaveObjectToPool(this); // manually save to pool, because we aren't going to save it in time
 		}
 	}
 

--- a/Assets/_Scripts/Game/GameController.cs
+++ b/Assets/_Scripts/Game/GameController.cs
@@ -475,7 +475,7 @@ public class GameController : MonoBehaviour
         return default;
     }
 
-    private void SaveObjectToPool(ITimeTracker timeTracker)
+    public void SaveObjectToPool(ITimeTracker timeTracker)
     {
         if (!ObjectTypeByID.TryGetValue(timeTracker.ID, out string type))
         {
@@ -513,10 +513,11 @@ public class GameController : MonoBehaviour
     /// <param name="timeEvent"></param>
     public void ExecuteEvent(TimeEvent timeEvent)
     {
-        Log($"ExecuteEvent({timeEvent.SourceID}, {timeEvent.Type.ToString()}, {timeEvent.TargetID}, {timeEvent.OtherData})");
+        
         ITimeTracker timeTracker = GetTimeTrackerByID(timeEvent.SourceID);
         if (timeTracker == null) // cannot find source object
         {
+            Log($"Failed: ExecuteEvent({timeEvent.SourceID}, {timeEvent.Type.ToString()}, {timeEvent.TargetID}, {timeEvent.OtherData})");
             if (timeEvent.Type == TimeEvent.EventType.TIME_TRAVEL)
             {
                 throw new TimeAnomalyException("Time Anomaly!", "Doppelganger was nowhere to be found to activate the Time Machine!");
@@ -524,6 +525,7 @@ public class GameController : MonoBehaviour
         }
         else
         {
+            Log($"ExecuteEvent({timeEvent.SourceID}, {timeEvent.Type.ToString()}, {timeEvent.TargetID}, {timeEvent.OtherData})");
             timeTracker.ExecutePastEvent(timeEvent);   
         }
     }
@@ -532,8 +534,7 @@ public class GameController : MonoBehaviour
     {
         int newID = NextID++;
         Explosion explosionObject = AcquireTimeTracker<Explosion>(TYPE_EXPLOSION);
-
-        // Init and add to trackers
+        
         Log($"{newID.ToString()}.Init()");
         explosionObject.Init(this, newID);
         explosionObject.FlagDestroy = false;

--- a/Assets/_Scripts/Game/GameController.cs
+++ b/Assets/_Scripts/Game/GameController.cs
@@ -989,6 +989,13 @@ public class GameController : MonoBehaviour
             RetryLevel();
             return;
         }
+        
+        // Remove popup if it exists
+        var retryPopups = FindObjectsOfType<RetryPopup>();
+        foreach (var popup in retryPopups)
+        {
+            Destroy(popup.gameObject); //TODO: destroying and recreating not the best idea long term... pool popup? make generic popup class?
+        }
 
         // load player snapshot from current state (at the timestep of the spawnState)
         int playerStartFrame = currentState.historyStartById[player.ID];

--- a/Assets/_Scripts/Game/ITimeTracker.cs
+++ b/Assets/_Scripts/Game/ITimeTracker.cs
@@ -81,6 +81,12 @@ public interface ITimeTracker : ICustomObject
     /// </summary>
     /// <param name="other">the object to copy from</param>
     void CopyTimeTrackerState(ITimeTracker other);
+
+    /// <summary>
+    ///     Execute a past event as given by the <see cref="GameController"/>
+    /// </summary>
+    /// <param name="timeEvent">The event this object should execute</param>
+    void ExecutePastEvent(TimeEvent timeEvent);
     
     /// <summary>
     ///     Method called by <see cref="GameController"/> to save a snapshot of this objects time-tracked variables

--- a/Assets/_Scripts/Game/PlayerController.cs
+++ b/Assets/_Scripts/Game/PlayerController.cs
@@ -94,7 +94,7 @@ public class PlayerController : MonoBehaviour, ITimeTracker
 
     public bool DidTimeTravel { get; set; }
     
-    /* TODO: TimeBool to track if the player is grounded (use to determine if past player is in valid location
+    /* TODO: TimeBool to track if the player is grounded (use to determine if Doppelganger is in valid location
      *       This is important in case player is standing on ground that moves/is destroyed
     */
     
@@ -285,7 +285,7 @@ public class PlayerController : MonoBehaviour, ITimeTracker
                 {
                     gameController.LogError($"Player {ID} could not grab {timeEvent.TargetID}");
                     throw new TimeAnomalyException("Time Anomaly!",
-                        $"Past player could not grab the {gameController.GetUserFriendlyName(timeEvent.TargetID)}");
+                        $"Doppelganger could not grab the {gameController.GetUserFriendlyName(timeEvent.TargetID)}");
                 }
             }
         } // end PLAYER_GRAB
@@ -296,6 +296,15 @@ public class PlayerController : MonoBehaviour, ITimeTracker
                 ItemID = -1;
             }
         } // end PLAYER_DROP
+        else if (timeEvent.Type == TimeEvent.EventType.TIME_TRAVEL)
+        {
+            TimeMachineController timeMachine = gameController.GetTimeTrackerByID(timeEvent.TargetID) as TimeMachineController;
+
+            if (timeMachine == null || !timeMachine.IsTouching(gameObject))
+            {
+                throw new TimeAnomalyException("Time Anomaly!", "Doppelganger could not activate the Time Machine!");
+            }
+        } // end TIME_TRAVEL
     }
 
     public void ClearActivate()

--- a/Assets/_Scripts/Game/PlayerController.cs
+++ b/Assets/_Scripts/Game/PlayerController.cs
@@ -105,7 +105,7 @@ public class PlayerController : MonoBehaviour, ITimeTracker
     public TimeBool ItemForm { get; } = null;
     public bool FlagDestroy { get; set; }
     public bool ShouldPoolObject => true;
-
+    
     public bool SetItemState(bool state) => false;
     
     public void CopyTimeTrackerState(ITimeTracker other)
@@ -172,7 +172,6 @@ public class PlayerController : MonoBehaviour, ITimeTracker
     }
 
     private bool queueGrab = false;
-    private bool prevQueueGrab = false;
     private static readonly int Walking = Animator.StringToHash("Walking");
 
     public void OnGrab(InputValue inputValue)
@@ -193,49 +192,17 @@ public class PlayerController : MonoBehaviour, ITimeTracker
 
     private void DoGrab()
     {
+        if (gameController.player != this) return; // only current player can initiate grab with this method
+        
         // to get the sprite 
         Sprite itemImage = gameController.tempImage; 
         bool isFound = false;
-        
-        if (gameController.player != this)
+
+        if (ItemID != -1) // not -1 means it is a valid item, so we ARE holding something
         {
-            if (ItemID != -1) // only check grabbing (not dropping) for past players
+            if (gameController.DropItem(this, ItemID)) // check to see if we successfully drop the item
             {
-                List<Collider2D> contacts = new List<Collider2D>();
-                GrabCollider.GetContacts(contacts);
-                foreach (var contact in contacts)
-                {
-                    if (contact.gameObject == gameObject) continue;
-
-                    ITimeTracker timeTracker = GameController.GetTimeTrackerComponent(contact.gameObject, true);
-                    if (timeTracker != null && timeTracker.ID == ItemID)
-                    {
-                        isFound = true;
-                    }
-
-                    // break the loop if we found an object bc we can only pick up one object
-                    if (isFound)
-                    {
-                        break;
-                    }
-                }
-
-                if (!isFound)
-                {
-                    gameController.LogError($"Player {ID} could not grab {ItemID}");
-                    throw new TimeAnomalyException("Oh No!",
-                        $"Past player could not grab {gameController.GetObjectTypeByID(ItemID)}");
-                }
-            }
-
-            return; // exit early because this is for the past player
-        }
-
-        if (ItemID != -1)
-        {
-            if (gameController.DropItem(ItemID)) // check to see if we successfully drop the item
-            {
-                ItemID = -1;
+                gameController.AddEvent(ID, TimeEvent.EventType.PLAYER_DROP, ItemID);
                 ItemID = -1;
                 gameController.playerItem.SetActive(false);
                 gameController.playerItem.GetComponentInChildren<Image>().sprite = itemImage;
@@ -271,11 +238,64 @@ public class PlayerController : MonoBehaviour, ITimeTracker
 			// this is when he grabs a object and it shows up in the screen 
 			if(isFound == true)
 			{
+                gameController.AddEvent(ID, TimeEvent.EventType.PLAYER_GRAB, ItemID);
 				gameController.playerItem.SetActive(true); // shows the screen to the player 
 				gameController.playerItem.GetComponentInChildren<Image>().sprite = itemImage;
 				Debug.Log("The name of the sprite is : " + itemImage.name);
 			}
         }
+    }
+    
+    public void ExecutePastEvent(TimeEvent timeEvent)
+    {
+        if(gameController.player == this) gameController.LogError($"ExecutePastEvent on current player!");
+        
+        if (timeEvent.Type == TimeEvent.EventType.PLAYER_GRAB)
+        {
+            bool isFound = false;
+            if (gameController.player != this)
+            {
+                if (ItemID != -1)
+                {
+                    gameController.LogError($"Trying to grab {timeEvent.TargetID} when already holding {ItemID}!");
+                }
+            
+                List<Collider2D> contacts = new List<Collider2D>();
+                GrabCollider.GetContacts(contacts);
+                foreach (var contact in contacts)
+                {
+                    if (contact.gameObject == gameObject) continue;
+
+                    ITimeTracker timeTracker = GameController.GetTimeTrackerComponent(contact.gameObject, true);
+                    if (timeTracker != null && timeTracker.ID == timeEvent.TargetID)
+                    {
+                        isFound = true;
+                    }
+
+                    // break the loop if we found the object bc we can only pick up one object
+                    if (isFound)
+                    {
+                        timeTracker.SetItemState(true);
+                        ItemID = timeEvent.TargetID;
+                        break;
+                    }
+                }
+
+                if (!isFound)
+                {
+                    gameController.LogError($"Player {ID} could not grab {timeEvent.TargetID}");
+                    throw new TimeAnomalyException("Time Anomaly!",
+                        $"Past player could not grab the {gameController.GetUserFriendlyName(timeEvent.TargetID)}");
+                }
+            }
+        } // end PLAYER_GRAB
+        else if (timeEvent.Type == TimeEvent.EventType.PLAYER_DROP)
+        {
+            if (gameController.DropItem(this, timeEvent.TargetID)) // check to see if we successfully drop the item
+            {
+                ItemID = -1;
+            }
+        } // end PLAYER_DROP
     }
 
     public void ClearActivate()
@@ -298,7 +318,6 @@ public class PlayerController : MonoBehaviour, ITimeTracker
         DidTimeTravel = false;
 
         queueGrab = false;
-        prevQueueGrab = false;
     }
 
     private void Update()
@@ -328,12 +347,9 @@ public class PlayerController : MonoBehaviour, ITimeTracker
 
     public void GameUpdate()
     {
-        if (!prevQueueGrab && queueGrab)
+        if (queueGrab) // this is only for the current player
         {
             DoGrab();
-        }
-        else
-        {
             queueGrab = false;
         }
     }
@@ -412,22 +428,18 @@ public class PlayerController : MonoBehaviour, ITimeTracker
     {
         Position.SaveSnapshot(snapshotDictionary, force);
         Velocity.SaveSnapshot(snapshotDictionary, force);
-        snapshotDictionary.Set(nameof(ItemID), ItemID, force);
+        snapshotDictionary.Set(nameof(ItemID), ItemID, force, clearFuture:true);
         snapshotDictionary.Set(nameof(Rigidbody.rotation), Rigidbody.rotation, force);
         snapshotDictionary.Set(nameof(isActivating), isActivating, force);
         snapshotDictionary.Set(nameof(DidTimeTravel), DidTimeTravel, force);
         //snapshotDictionary[nameof(GetCollisionStateString)] = GetCollisionStateString();
         snapshotDictionary.Set(GameController.FLAG_DESTROY, FlagDestroy, force);
         //NOTE: players should never be in item form, so don't save/load that info here
-        
-        snapshotDictionary.Set(nameof(queueGrab), queueGrab, force);
-        prevQueueGrab = queueGrab;
     }
 
     // TODO: add fixed frame # associated with snapshot? and Lerp in update loop?!
     public void LoadSnapshot(TimeDict.TimeSlice snapshotDictionary)
     {
-        ItemID = snapshotDictionary.Get<int>(nameof(ItemID));
         Position.LoadSnapshot(snapshotDictionary);
         Velocity.LoadSnapshot(snapshotDictionary);
 
@@ -435,9 +447,6 @@ public class PlayerController : MonoBehaviour, ITimeTracker
         {
             Position.Current = Position.History;
             Velocity.Current = Velocity.History;
-            
-            queueGrab = snapshotDictionary.Get<bool>(nameof(queueGrab));
-            prevQueueGrab = gameController.GetSnapshotValue<bool>(this, gameController.TimeStep-1, nameof(queueGrab));;
         }
 
         Rigidbody.rotation = snapshotDictionary.Get<float>(nameof(Rigidbody.rotation));
@@ -459,9 +468,6 @@ public class PlayerController : MonoBehaviour, ITimeTracker
         Rigidbody.rotation = snapshotDictionary.Get<float>(nameof(Rigidbody.rotation));
         historyActivating = snapshotDictionary.Get<bool>(nameof(isActivating));
         DidTimeTravel = snapshotDictionary.Get<bool>(nameof(DidTimeTravel));
-        
-        queueGrab = snapshotDictionary.Get<bool>(nameof(queueGrab));
-        prevQueueGrab = gameController.GetSnapshotValue<bool>(this, gameController.TimeStep-1, nameof(queueGrab));
         
         FlagDestroy = snapshotDictionary.Get<bool>(GameController.FLAG_DESTROY);
     }

--- a/Assets/_Scripts/Game/TimeEvent.cs
+++ b/Assets/_Scripts/Game/TimeEvent.cs
@@ -10,6 +10,7 @@ public struct TimeEvent
         PLAYER_DROP,
         EXPLODE,
         GUARD_SHOOT,
+        TIME_TRAVEL,
         
         COUNT
     }

--- a/Assets/_Scripts/Game/TimeEvent.cs
+++ b/Assets/_Scripts/Game/TimeEvent.cs
@@ -1,0 +1,29 @@
+﻿
+
+public struct TimeEvent
+{
+    public enum EventType
+    {
+        NONE = -1,
+        
+        PLAYER_GRAB,
+        PLAYER_DROP,
+        EXPLODE,
+        GUARD_SHOOT,
+        
+        COUNT
+    }
+
+    public EventType Type;
+    public int SourceID;
+    public int TargetID;
+    public string OtherData;
+
+    public TimeEvent(int sourceID, EventType type, int targetID, string otherData = null)
+    {
+        SourceID = sourceID;
+        Type = type;
+        TargetID = targetID;
+        OtherData = otherData;
+    }
+}

--- a/Assets/_Scripts/Game/TimeEvent.cs.meta
+++ b/Assets/_Scripts/Game/TimeEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d10da6d388de4a1daaac1df99fd77b9b
+timeCreated: 1618686061

--- a/Assets/_Scripts/Game/TimeVariable.cs
+++ b/Assets/_Scripts/Game/TimeVariable.cs
@@ -82,12 +82,15 @@ public class TimeVector : TimeVariable<Vector2>
     private readonly Action<Vector2> _setter;
     private readonly Func<Vector2> _getter;
 
+    private bool _canClearFuturePosition;
+    
     private Vector2 _current;
 
-    public TimeVector(string name, Action<Vector2> setter = null, Func<Vector2> getter = null) : base(name)
+    public TimeVector(string name, Action<Vector2> setter = null, Func<Vector2> getter = null, bool canClearFuturePosition = false) : base(name)
     {
         _setter = setter;
         _getter = getter;
+        _canClearFuturePosition = canClearFuturePosition;
     }
 
     public override Vector2 Current
@@ -117,9 +120,16 @@ public class TimeVector : TimeVariable<Vector2>
     
     public override void SaveSnapshot(TimeDict.TimeSlice snapshotDictionary, bool force=false)
     {
-        Vector2 temp = Current;
-        snapshotDictionary.Set(CurrentName, temp, force);
+        bool clearPositionFuture = false;
+        if (_canClearFuturePosition)
+        {
+            clearPositionFuture = Vector2.Distance(Current, History) >
+                                  GameController.POSITION_CLEAR_FUTURE_THRESHOLD;
+        }
         
-        snapshotDictionary.Set(HistoryName, temp == Vector2.negativeInfinity ? History : temp, force);
+        Vector2 temp = Current;
+        snapshotDictionary.Set(CurrentName, temp, force, clearPositionFuture);
+        
+        snapshotDictionary.Set(HistoryName, temp == Vector2.negativeInfinity ? History : temp, force, clearPositionFuture);
     }
 }

--- a/Assets/_Scripts/Tests/TimeDictUnitTests.cs
+++ b/Assets/_Scripts/Tests/TimeDictUnitTests.cs
@@ -88,6 +88,31 @@ namespace Tests
         }
         
         [Test]
+        public void VariableTimelineClearFutureTest()
+        {
+            VariableTimeline<int> timeline = new VariableTimeline<int>();
+            
+            Assert.AreEqual(0, timeline.Get(0)); // default is 0
+            
+            timeline.Set(10, 55);
+            Assert.AreEqual(0, timeline.Get(0)); // before point still 0
+            Assert.AreEqual(55, timeline.Get(10)); // at point is 55
+            Assert.AreEqual(55, timeline.Get(20)); // after point is 55
+            
+            timeline.Set(25, 1111);
+            Assert.AreEqual(55, timeline.Get(15));
+            Assert.AreEqual(1111, timeline.Get(25));
+            Assert.AreEqual(1111, timeline.Get(30));
+            
+            timeline.Set(5, 333, force:true, clearFuture:true);
+            Assert.AreEqual(0, timeline.Get(0));        // before is still 0
+            Assert.AreEqual(333, timeline.Get(10));     // rest are 333 because of clearFuture
+            Assert.AreEqual(333, timeline.Get(15));
+            Assert.AreEqual(333, timeline.Get(25));
+            Assert.AreEqual(333, timeline.Get(30));
+        }
+
+        [Test]
         public void TimeDictTest()
         {
             TimeDict history = new TimeDict();
@@ -105,6 +130,13 @@ namespace Tests
             Assert.AreEqual(55, history.Get<int>(15, "int_var"));
             Assert.AreEqual(1111, history.Get<int>(25, "int_var"));
             Assert.AreEqual(1111, history.Get<int>(30, "int_var"));
+            
+            history.Set(5, "int_var", 333, force:true, clearFuture:true);
+            Assert.AreEqual(0, history.Get<int>(0, "int_var"));        // before is still 0
+            Assert.AreEqual(333, history.Get<int>(10, "int_var"));     // rest are 333 because of clearFuture
+            Assert.AreEqual(333, history.Get<int>(15, "int_var"));
+            Assert.AreEqual(333, history.Get<int>(25, "int_var"));
+            Assert.AreEqual(333, history.Get<int>(30, "int_var"));
         }
     }
 }


### PR DESCRIPTION
Fixes a bunch of bugs. See commit messages for full list.

Fixes:
- Issues with player grabbing doppelganger's boxes and the anomalies surrounding that
- Issues with multiple explosions spawning from the same box in time (solution a little hacky... involves setting FLAG_DESTROY on TimeStep=0 to true when the object despawns. Might revisit more proper solution in Beta)
- Added user-friendly names to anomaly messages
- Issue with pressing 'R' not removing popup
- maybe some smaller ones I'm not thinking of rn
