### PR TITLE
Past players appear darker

### DIFF
--- a/Assets/Scenes/aaronTest.unity
+++ b/Assets/Scenes/aaronTest.unity
@@ -728,11 +728,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9128684925753525160, guid: 2e7b58ec48b19574e91ef3afa209e343, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -11.151918
+      value: -1.87
       objectReference: {fileID: 0}
     - target: {fileID: 9128684925753525160, guid: 2e7b58ec48b19574e91ef3afa209e343, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.6723187
+      value: -0.91
       objectReference: {fileID: 0}
     - target: {fileID: 9128684925753525160, guid: 2e7b58ec48b19574e91ef3afa209e343, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/_Scripts/Game/PlayerController.cs
+++ b/Assets/_Scripts/Game/PlayerController.cs
@@ -237,6 +237,23 @@ public class PlayerController : MonoBehaviour, ITimeTracker
         {
             SpriteRenderer.flipX = _rigidbody.velocity.x > 0;
         }
+        if (gameController.player != this)
+        {
+            Color temp = SpriteRenderer.color;
+            temp.r = 0.5f;
+            temp.g = 0.5f;
+            temp.b = 0.5f;
+            SpriteRenderer.color = temp;
+        }
+        else
+        {
+            Color temp = SpriteRenderer.color;
+            temp.r = 1.0f;
+            temp.g = 1.0f;
+            temp.b = 1.0f;
+            SpriteRenderer.color = temp;
+        }
+
     }
 
     void FixedUpdate()
@@ -301,7 +318,7 @@ public class PlayerController : MonoBehaviour, ITimeTracker
         this.gameController = gameController;
         ID = id;
         name = $"Player {id.ToString()}";
-        
+
         Position = new TimeVector("Position", x => Rigidbody.position = x, () => Rigidbody.position);
         Velocity = new TimeVector("Velocity", x => Rigidbody.velocity = x, () => Rigidbody.velocity);
     }


### PR DESCRIPTION
Upon going back in time, the past players will appear more grayed out while the controlled player is still in full color (visual difference may change later on), checked with multiple past players on screen and upon respawning after getting hit by guard