### PR TITLE
Fixing issue with multiple time travels and respawning causes current player to disappear

### DIFF
--- a/Assets/_Scripts/CameraTracker.cs
+++ b/Assets/_Scripts/CameraTracker.cs
@@ -37,12 +37,12 @@ public class CameraTracker : MonoBehaviour
     {
         if (gameController.TimeStep > 0)
         {
-            Vector2 playerPos = gameController.GetSnapshotValue<Vector2>(gameController.player, gameController.TimeStep,
-                gameController.player.Position.CurrentName, defaultValue:Vector2.positiveInfinity);
+            Vector2 playerPos = gameController.GetSnapshotValue<Vector2>(gameController.Player, gameController.TimeStep,
+                gameController.Player.Position.CurrentName, defaultValue:Vector2.positiveInfinity);
 
             if (float.IsPositiveInfinity(playerPos.x) && float.IsPositiveInfinity(playerPos.y))
             {
-                playerPos = gameController.player.Position.Current;
+                playerPos = gameController.Player.Position.Current;
             }
             
             //Follow the player's position

--- a/Assets/_Scripts/Game/GameController.cs
+++ b/Assets/_Scripts/Game/GameController.cs
@@ -839,7 +839,9 @@ public class GameController : MonoBehaviour
             TimeTrackerObjects.TryGetValue(id, out var timeTracker);
             if (timeTracker != null && timeTracker.ID != id) // ID mismatch, remove here, and potentially recreate below
             {
+                SaveObjectToPool(timeTracker);
                 TimeTrackerObjects.Remove(id);
+                AllReferencedObjects.Remove(id);
                 timeTracker = null;
             }
             if (!alreadyDestroyed

--- a/Assets/_Scripts/Game/PlayerController.cs
+++ b/Assets/_Scripts/Game/PlayerController.cs
@@ -132,7 +132,7 @@ public class PlayerController : MonoBehaviour, ITimeTracker
     //---PlayerInputs---
     public void OnMove(InputValue movementValue)
     {
-        if (gameController.player != this) return;
+        if (gameController.Player != this) return;
 
         Vector2 movementVector = movementValue.Get<Vector2>();
 
@@ -141,39 +141,39 @@ public class PlayerController : MonoBehaviour, ITimeTracker
     }
     public void OnJump(InputValue inputValue)
     {
-        if (gameController.player != this) return;
+        if (gameController.Player != this) return;
 
         jump |= inputValue.isPressed && isGrounded;
     }
     public void OnActivate(InputValue inputValue)
     {
-        if (gameController.player != this) return;
+        if (gameController.Player != this) return;
 
         isActivating = inputValue.isPressed;
     }
     public void OnSkipTime(InputValue inputValue)
     {
-        if (gameController.player != this) return;
+        if (gameController.Player != this) return;
 
         gameController.SkipTime();
     }
     public void OnSaveDebugHistory(InputValue inputValue)
     {
-        if (gameController.player != this) return;
+        if (gameController.Player != this) return;
 
         gameController.ExportHistory();
     }
 
     public void OnRetry(InputValue inputValue)
     {
-        if (gameController.player != this) return;
+        if (gameController.Player != this) return;
 
         gameController.RetryLevel();
     }
 
     public void OnRespawn(InputValue inputValue)
     {
-        if (gameController.player != this) return;
+        if (gameController.Player != this) return;
 
         gameController.RespawnLatest();
     }
@@ -185,7 +185,7 @@ public class PlayerController : MonoBehaviour, ITimeTracker
 
     public void OnGrab(InputValue inputValue)
     {
-        if (gameController.player != this) return;
+        if (gameController.Player != this) return;
         
         queueGrab = true;
     }
@@ -201,7 +201,7 @@ public class PlayerController : MonoBehaviour, ITimeTracker
 
     private void DoGrab()
     {
-        if (gameController.player != this) return; // only current player can initiate grab with this method
+        if (gameController.Player != this) return; // only current player can initiate grab with this method
         
         // to get the sprite 
         Sprite itemImage = gameController.tempImage;
@@ -269,12 +269,12 @@ public class PlayerController : MonoBehaviour, ITimeTracker
     
     public void ExecutePastEvent(TimeEvent timeEvent)
     {
-        if(gameController.player == this) gameController.LogError($"ExecutePastEvent on current player!");
+        if(gameController.Player == this) gameController.LogError($"ExecutePastEvent on current player!");
         
         if (timeEvent.Type == TimeEvent.EventType.PLAYER_GRAB)
         {
             bool isFound = false;
-            if (gameController.player != this)
+            if (gameController.Player != this)
             {
                 if (ItemID != -1)
                 {
@@ -368,7 +368,7 @@ public class PlayerController : MonoBehaviour, ITimeTracker
 
         SpriteRenderer.flipX = facingRight;
         
-        if (gameController.player != this)
+        if (gameController.Player != this)
         {
             Color temp = SpriteRenderer.color;
             temp.r = 0.5f;
@@ -392,7 +392,7 @@ public class PlayerController : MonoBehaviour, ITimeTracker
 
         UpdateIsGrounded();
 
-        if (this != gameController.player) return; // don't update physics from inputs if not main player
+        if (this != gameController.Player) return; // don't update physics from inputs if not main player
 
         if (jump)
         {
@@ -461,7 +461,6 @@ public class PlayerController : MonoBehaviour, ITimeTracker
 
         Position = new TimeVector("Position", x => Rigidbody.position = x, () => Rigidbody.position);
         Velocity = new TimeVector("Velocity", x => Rigidbody.velocity = x, () => Rigidbody.velocity);
-
     }
 
     public string GetCollisionStateString()
@@ -472,7 +471,7 @@ public class PlayerController : MonoBehaviour, ITimeTracker
         List<string> colliderStrings = new List<string>();
         foreach (var collider in contactColliders)
         {
-            if (collider.gameObject == gameController.player.gameObject || collider.gameObject == this.gameObject) continue;
+            if (collider.gameObject == gameController.Player.gameObject || collider.gameObject == this.gameObject) continue;
             
             ITimeTracker timeTracker = GameController.GetTimeTrackerComponent(collider.gameObject);
             if (timeTracker != null)
@@ -510,7 +509,7 @@ public class PlayerController : MonoBehaviour, ITimeTracker
         Position.LoadSnapshot(snapshotDictionary);
         Velocity.LoadSnapshot(snapshotDictionary);
 
-        if (gameController.player != this) // we don't want the current player to revert to their history positions/velocity
+        if (gameController.Player != this) // we don't want the current player to revert to their history positions/velocity
         {
             Position.Current = Position.History;
             Velocity.Current = Velocity.History;

--- a/Assets/_Scripts/Game/Shoot.cs
+++ b/Assets/_Scripts/Game/Shoot.cs
@@ -74,14 +74,14 @@ public class Shoot : MonoBehaviour
             }
         }
 
-        dist = Mathf.Abs(Vector2.Distance(gameObject.transform.position, gameController.GetComponent<GameController>().player.transform.position));
-        direc = gameController.GetComponent<GameController>().player.transform.position - gameObject.transform.position;
+        dist = Mathf.Abs(Vector2.Distance(gameObject.transform.position, gameController.GetComponent<GameController>().Player.transform.position));
+        direc = gameController.GetComponent<GameController>().Player.transform.position - gameObject.transform.position;
         angle = Mathf.Atan2(direc.y, direc.x) * Mathf.Rad2Deg;
         angle = Mathf.Abs(angle);
         if (dist < minDist && (angle <= 45 || angle >= 135))
         {
             minDist = dist;
-            closest = gameController.GetComponent<GameController>().player.gameObject;
+            closest = gameController.GetComponent<GameController>().Player.gameObject;
         }
         if(!seen && (minDist <= range))
         {

--- a/Assets/_Scripts/Game/TextToggle.cs
+++ b/Assets/_Scripts/Game/TextToggle.cs
@@ -17,7 +17,7 @@ public class TextToggle : MonoBehaviour
 
     void OnTriggerEnter2D(Collider2D other)
     {
-		if(other == gameController.player.CapsuleCollider)
+		if(other == gameController.Player.CapsuleCollider)
 		{
 			childObject.SetActive(true);
 		}
@@ -25,7 +25,7 @@ public class TextToggle : MonoBehaviour
 
     void OnTriggerExit2D(Collider2D other)
     {
-		if(other == gameController.player.CapsuleCollider)
+		if(other == gameController.Player.CapsuleCollider)
 		{
 			childObject.SetActive(false);	
 		}	

--- a/Assets/_Scripts/System/Pool.cs
+++ b/Assets/_Scripts/System/Pool.cs
@@ -35,6 +35,9 @@ public class Pool<T>
     public void Release(T obj)
     {
         release.Invoke(obj);
-        available.Enqueue(obj);
+        if (!available.Contains(obj))
+        {
+            available.Enqueue(obj);
+        }
     }
 }

--- a/Assets/_Scripts/Tests/IntegrationTests.cs
+++ b/Assets/_Scripts/Tests/IntegrationTests.cs
@@ -22,8 +22,8 @@ namespace Tests
             _game = Object.Instantiate(Resources.Load<GameObject>("Prefabs/GameController")).GetComponent<GameController>();
             
             PlayerController playerPrefab = Resources.Load<PlayerController>("Prefabs/Player");
-            _game.player = Object.Instantiate(playerPrefab).GetComponent<PlayerController>();
-            _game.player.PlayerInput.enabled = true;
+            //_game.Player = Object.Instantiate(playerPrefab).GetComponent<PlayerController>();
+            _game.Player.PlayerInput.enabled = true;
             
             TimeMachineController timeMachine = Object.Instantiate(Resources.Load<GameObject>("Prefabs/TimeMachine")).GetComponent<TimeMachineController>();
             BasicTimeTracker moveableBox = Object.Instantiate(Resources.Load<GameObject>("Prefabs/MoveableBox")).GetComponent<BasicTimeTracker>();
@@ -45,7 +45,7 @@ namespace Tests
             
             Assert.IsFalse(timeMachine.IsActivatedOrOccupied);
             Assert.AreEqual(-1, timeMachine.Countdown.Current);
-            Assert.IsFalse(_game.player.IsActivating);
+            Assert.IsFalse(_game.Player.IsActivating);
             yield return null;
 
             PressAndRelease(_keyboard.spaceKey);


### PR DESCRIPTION
- Fixes some issues in the GameState that were not being properly synced.
- Moves the `player` variable in GameController to an accessor that retrieves the object from the dictionary based off the ID of the GameState
- Most importantly: when respawning, `LoadSnapshotFull()` now ensures that the timetrackers have the expected IDs incase they had stale references and need to be reinitialized.