### PR TITLE
Bugfix fold timemachine

### DIFF
--- a/Assets/Resources/Prefabs/TimeMachine.prefab
+++ b/Assets/Resources/Prefabs/TimeMachine.prefab
@@ -204,7 +204,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: 7591ae6fc47e380439c5be943b37d726, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/Assets/Resources/Sprites/TimeMachine/TimeMachine.controller
+++ b/Assets/Resources/Sprites/TimeMachine/TimeMachine.controller
@@ -60,9 +60,6 @@ AnimatorStateTransition:
   - m_ConditionMode: 2
     m_ConditionEvent: AnimateOpen
     m_EventTreshold: 0
-  - m_ConditionMode: 2
-    m_ConditionEvent: IsFoldable
-    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 2214962682132048240}
   m_Solo: 0
@@ -140,10 +137,7 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 2
-    m_ConditionEvent: IsFoldable
-    m_EventTreshold: 0
+  m_Conditions: []
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -6431540363454061018}
   m_Solo: 0
@@ -168,9 +162,6 @@ AnimatorStateTransition:
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: AnimateOpen
-    m_EventTreshold: 0
-  - m_ConditionMode: 1
-    m_ConditionEvent: IsFoldable
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 4589933439212156643}
@@ -275,31 +266,31 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsFoldable
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: AnimateFolding
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: AnimateUnfolding
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsItem
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: AnimationState
@@ -351,9 +342,6 @@ AnimatorStateTransition:
   - m_ConditionMode: 2
     m_ConditionEvent: AnimateOpen
     m_EventTreshold: 0
-  - m_ConditionMode: 1
-    m_ConditionEvent: IsFoldable
-    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -5859867638896827105}
   m_Solo: 0
@@ -404,10 +392,7 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: IsFoldable
-    m_EventTreshold: 0
+  m_Conditions: []
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 118537082913107671}
   m_Solo: 0
@@ -432,9 +417,6 @@ AnimatorStateTransition:
   m_Conditions:
   - m_ConditionMode: 1
     m_ConditionEvent: AnimateOpen
-    m_EventTreshold: 0
-  - m_ConditionMode: 2
-    m_ConditionEvent: IsFoldable
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 3139848894724619737}
@@ -593,7 +575,7 @@ AnimatorStateMachine:
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: -240, y: 240, z: 0}
-  m_EntryPosition: {x: -280, y: -170, z: 0}
+  m_EntryPosition: {x: -320, y: -180, z: 0}
   m_ExitPosition: {x: -500, y: 200, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 2214962682132048240}

--- a/Assets/Resources/Sprites/TimeMachine/TimeMachine.controller
+++ b/Assets/Resources/Sprites/TimeMachine/TimeMachine.controller
@@ -418,6 +418,9 @@ AnimatorStateTransition:
   - m_ConditionMode: 1
     m_ConditionEvent: AnimateOpen
     m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: IsFoldable
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 3139848894724619737}
   m_Solo: 0
@@ -560,7 +563,7 @@ AnimatorStateMachine:
     m_Position: {x: -390, y: 40, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -3234503830745115872}
-    m_Position: {x: -160, y: 40, z: 0}
+    m_Position: {x: -130, y: 60, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 118537082913107671}
     m_Position: {x: 30, y: 160, z: 0}
@@ -700,6 +703,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &7000331256456621833
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: IsItem
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5859867638896827105}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &8889912973269219863
 AnimatorStateTransition:
   m_ObjectHideFlags: 3
@@ -737,6 +765,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 5999657421558113545}
+  - {fileID: 7000331256456621833}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/_Scripts/Game/PlayerController.cs
+++ b/Assets/_Scripts/Game/PlayerController.cs
@@ -276,7 +276,9 @@ public class PlayerController : MonoBehaviour, ITimeTracker
                     if (contact.gameObject == gameObject) continue;
 
                     ITimeTracker timeTracker = GameController.GetTimeTrackerComponent(contact.gameObject, true);
-                    if (timeTracker != null && timeTracker.ID == timeEvent.TargetID)
+                    if (timeTracker == null) continue;
+                    
+                    if (timeTracker.ID == timeEvent.TargetID)
                     {
                         isFound = true;
                     }

--- a/Assets/_Scripts/Game/TimeMachineController.cs
+++ b/Assets/_Scripts/Game/TimeMachineController.cs
@@ -395,6 +395,7 @@ public class TimeMachineController : MonoBehaviour, ITimeTracker
         snapshotDictionary.Set(nameof(IsAnimatingFold), IsAnimatingFold);
         snapshotDictionary.Set(nameof(IsAnimatingUnfold), IsAnimatingUnfold);
         snapshotDictionary.Set(nameof(playerID), playerID, force);
+        snapshotDictionary.Set(nameof(isFoldable), isFoldable, force);
         Position.SaveSnapshot(snapshotDictionary, force);
     }
 
@@ -438,6 +439,9 @@ public class TimeMachineController : MonoBehaviour, ITimeTracker
         IsAnimatingUnfold = snapshotDictionary.Get<bool>(nameof(IsAnimatingUnfold));
         animator.SetBool(AnimateUnfolding, IsAnimatingUnfold);
         playerID = snapshotDictionary.Get<int>(nameof(playerID));
+        isFoldable = snapshotDictionary.Get<bool>(nameof(isFoldable));
+        animator.SetBool(AnimIsFoldable, isFoldable);
+        animator.SetBool(AnimIsItem, ItemForm);
         
         gameObject.SetActive((!ItemForm && !FlagDestroy) || IsAnimatingFold);
     }

--- a/Assets/_Scripts/Game/TimeMachineController.cs
+++ b/Assets/_Scripts/Game/TimeMachineController.cs
@@ -409,11 +409,11 @@ public class TimeMachineController : MonoBehaviour, ITimeTracker
 
         gameObject.SetActive((!ItemForm && !FlagDestroy) || IsAnimatingFold);
 
-        IsAnimatingOpenClose |= snapshotDictionary.Get<bool>(nameof(IsAnimatingOpenClose));
+        IsAnimatingOpenClose = snapshotDictionary.Get<bool>(nameof(IsAnimatingOpenClose));
         animator.SetBool(AnimateOpen, IsAnimatingOpenClose);
-        IsAnimatingFold |= snapshotDictionary.Get<bool>(nameof(IsAnimatingFold));
+        IsAnimatingFold = snapshotDictionary.Get<bool>(nameof(IsAnimatingFold));
         animator.SetBool(AnimateFolding, IsAnimatingFold);
-        IsAnimatingUnfold |= snapshotDictionary.Get<bool>(nameof(IsAnimatingUnfold));
+        IsAnimatingUnfold = snapshotDictionary.Get<bool>(nameof(IsAnimatingUnfold));
         animator.SetBool(AnimateUnfolding, IsAnimatingUnfold);
         
         Occupied.Current &= Activated.History;


### PR DESCRIPTION
- Fixes multiple animation state issues with the time tracked data for the Time Machines. The animation state was getting stuck in a certain loop, so removed the `isFoldable=false` requirement for the middle and ending frames of the animation so that it could escape if need be. Also added transition from `IsItem` to the base state when `false`.
- Also fixes the color being incorrect (sprite order was the same, so adjusted that)
- Also fixes bug with player trying to grab null TimeTracker when looking for a Time Machine (now continues in loop if null)