### PR TITLE
Fixed issue with dropping box through doors

### DIFF
--- a/Assets/Resources/Prefabs/Door.prefab
+++ b/Assets/Resources/Prefabs/Door.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 944341154}
   - component: {fileID: 944341155}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: DoorOpen
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -91,7 +91,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1244586114644612940}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Art
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -125,7 +125,7 @@ GameObject:
   - component: {fileID: 8877231957068217834}
   - component: {fileID: 8877231957068217623}
   - component: {fileID: 8877231957068217832}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: DoorClosed
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -234,7 +234,7 @@ GameObject:
   - component: {fileID: 8877231957090316387}
   - component: {fileID: 432367698}
   - component: {fileID: 7931513886117028449}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Door
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -289,4 +289,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   matchBoxCollider: 0
   matchSpriteRenderer: 0
+  matchRectTransform: 0
   gridSize: 0.5

--- a/Assets/Resources/Prefabs/Platform.prefab
+++ b/Assets/Resources/Prefabs/Platform.prefab
@@ -124,4 +124,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   matchBoxCollider: 0
   matchSpriteRenderer: 1
+  matchRectTransform: 0
   gridSize: 0.5

--- a/Assets/Scenes/Alpha_03_BoxesAndGates.unity
+++ b/Assets/Scenes/Alpha_03_BoxesAndGates.unity
@@ -503,11 +503,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1920048977343419216, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
       propertyPath: m_SpriteTilingProperty.newSize.x
-      value: 3.2588592
+      value: 3.5
       objectReference: {fileID: 0}
     - target: {fileID: 1920048977343419216, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
       propertyPath: m_SpriteTilingProperty.newSize.y
-      value: 5.1081066
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 1920048977343419216, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
       propertyPath: m_Size.x
@@ -1159,11 +1159,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1920048977343419216, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
       propertyPath: m_SpriteTilingProperty.newSize.x
-      value: 4.351124
+      value: 4.5
       objectReference: {fileID: 0}
     - target: {fileID: 1920048977343419216, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
       propertyPath: m_SpriteTilingProperty.newSize.y
-      value: 23.279924
+      value: 23.5
       objectReference: {fileID: 0}
     - target: {fileID: 1920048977343419216, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
       propertyPath: m_Size.x
@@ -1176,10 +1176,6 @@ PrefabInstance:
     - target: {fileID: 1920048977343419217, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
       propertyPath: m_Name
       value: LeftWall
-      objectReference: {fileID: 0}
-    - target: {fileID: 1920048977343419217, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
-      propertyPath: m_Layer
-      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 1920048977343419218, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1253,11 +1249,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1920048977343419216, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
       propertyPath: m_SpriteTilingProperty.newSize.x
-      value: 3.2164326
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1920048977343419216, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
       propertyPath: m_SpriteTilingProperty.newSize.y
-      value: 4.2443447
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 1920048977343419216, guid: fe62a2342957a6a459eb46911d12f788, type: 3}
       propertyPath: m_Size.x

--- a/Assets/_Scripts/Game/GameController.cs
+++ b/Assets/_Scripts/Game/GameController.cs
@@ -977,11 +977,13 @@ public class GameController : MonoBehaviour
             Log($"Drop Item {targetID.ToString()}");
             Vector2 dropPos = droppingPlayer.Position.Get + new Vector2(droppingPlayer.facingRight ? 1.2f : -1.2f, 0);
             
-            RaycastHit2D raycastHit = Physics2D.Raycast(droppingPlayer.Position.Get, droppingPlayer.facingRight ? Vector2.right : Vector2.left, 1.2f, LayerMask.NameToLayer("LevelPlatforms"));
-            if (raycastHit.collider != null)
+            RaycastHit2D[] raycastHits = Physics2D.RaycastAll(droppingPlayer.Position.Get, droppingPlayer.facingRight ? Vector2.right : Vector2.left, 1.2f);
+            foreach (var hit in raycastHits)
             {
+                if (hit.collider.gameObject.layer != LayerMask.NameToLayer("LevelPlatforms")) continue;
                 // set drop position to halfway between player and collision
-                dropPos = (raycastHit.point + droppingPlayer.Position.Get) / 2;
+                dropPos = (hit.point + droppingPlayer.Position.Get) / 2;
+                break;
             }
 
             timeTracker.Position.Current = dropPos;


### PR DESCRIPTION
`Physics2D.Raycast` wasn't returning any objects with the layer mask on. So I instead used `Physics2D.RaycastAll`

Put Doors in the `LevelPlatforms` layer. This also fixes the issue of dropping a Time Machine on top of a door.